### PR TITLE
Renames Bram.mailbox to Bram.listen

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,18 @@ Communication in Bram happens through observables. Borrowing the [mailbox concep
 
       created: function(bind, shadow){
         let button = shadow.querySelector('button');
-        let clicks = Rx.Observable.fromEvent(button, 'click');
+        let clicks = Rx.Observable.fromEvent(button, 'click')
+          .map(() => ({ type: 'click' }));
         Bram.send(this, clicks);
 
         bind.text(".count", this.count);
       }
     });
 
-    let count = Bram.mailbox()
+    let messages = Bram.listen();
+
+    let count = messages
+      .filter(ev => ev.type === 'click')
       .startWith(0)
       .scan(value => value + 1);
 

--- a/examples/clicks/clicks.js
+++ b/examples/clicks/clicks.js
@@ -5,14 +5,18 @@ Bram.element({
   props: ["count"],
 
   created: function(bind, shadow){
-    var clicks = Rx.Observable.fromEvent(shadow.querySelector('button'), 'click');
+    var clicks = Rx.Observable.fromEvent(shadow.querySelector('button'), 'click')
+      .map(() => ({ type: 'click' }));
     Bram.send(this, clicks);
 
     bind.text(".count", this.count);
   }
 });
 
-var count = Bram.mailbox()
+var messages = Bram.listen();
+
+var count = messages
+  .filter(ev => ev.type === 'click')
   .startWith(0)
   .scan(value => value + 1);
 

--- a/examples/name-form/name.js
+++ b/examples/name-form/name.js
@@ -3,13 +3,13 @@ Bram.element({
   template: "#user-template",
 
   created: function(bind){
-    var mailbox = Bram.mailbox();
+    var messages = Bram.listen();
 
-    var first = mailbox.filter(ev => ev.type === 'first')
+    var first = messages.filter(ev => ev.type === 'first')
       .map(ev => ev.value)
       .startWith("");
 
-    var last = mailbox.filter(ev => ev.type === 'last')
+    var last = messages.filter(ev => ev.type === 'last')
       .map(ev => ev.value)
       .startWith("");
 

--- a/examples/todos/app.js
+++ b/examples/todos/app.js
@@ -50,7 +50,9 @@ Bram.element({
       items: state.items.filter(todo => todo.value !== item.value)
     });
 
-   var state = Bram.mailbox()
+  var messages = Bram.listen();
+
+   var state = messages
     .startWith({ items: [{ value: 'Make an app' }] })
     .scan(function(state, ev){
       switch(ev.type) {

--- a/lib/bram.js
+++ b/lib/bram.js
@@ -8,7 +8,7 @@ var CID = supportsSymbol ? Symbol("[[BramCID]]") : "[[BramCID]]";
 var slice = Array.prototype.slice;
 
 function makeObservable(element, eventName) {
-  return Bram.listen(element, eventName)
+  return Bram.on(element, eventName)
     .map(function(ev) {
       ev.stopPropagation();
       return ev.detail;
@@ -148,7 +148,7 @@ else {
   return;
 }
 
-Bram.listen = function(element, eventName){
+Bram.on = function(element, eventName){
   return Bram.Observable.fromEvent
     ? Bram.Observable.fromEvent(element, eventName)
     : new Bram.Observable(function(observer){
@@ -166,10 +166,10 @@ Bram.listen = function(element, eventName){
   });
 }
 
-Bram.mailbox = function(element){
-  var address = 'bram-appchange';
+Bram.listen = function(element){
+  var eventName = 'bram-appchange';
   if(arguments.length === 1) {
-    // element-contextual address
+    // element-contextual eventName
     var proto = Object.getPrototypeOf(element);
     if(!proto[CID]) {
       Object.defineProperty(proto, CID, {
@@ -178,19 +178,21 @@ Bram.mailbox = function(element){
       });
     }
     var cid = proto[CID]++;
-    address = address + '-' + element.tagName.toLowerCase() + '-' + cid;
+    eventName = eventName + '-' + element.tagName.toLowerCase() + '-' + cid;
 
     element.send = function(observable){
-      Bram.send(this, observable, address, false);
+      Bram.send(this, observable, eventName, false);
     };
   }
   element = element || document.body;
 
-  var observable = Bram.listen(element, address);
-  return observable.map(function(ev) {
-    ev.stopPropagation();
-    return ev.detail;
-  });
+  var observable = Bram.on(element, eventName)
+    .map(function(ev) {
+      ev.stopPropagation();
+      return ev.detail;
+    });
+  observable.eventName = eventName;
+  return observable;
 };
 
 Bram.trigger = function(el, val, eventName, bubbles){

--- a/test/listen.js
+++ b/test/listen.js
@@ -1,0 +1,15 @@
+QUnit.module('Bram.listen');
+
+QUnit.test('Receives messages from Bram.trigger', function(assert){
+  assert.expect(1);
+
+  var messages = Bram.listen();
+
+  var subscription = messages.subscribe(function(ev){
+    assert.equal(ev.type, 'hello', 'Got the hello message');
+    subscription.dispose();
+  });
+
+  var el = document.querySelector('#qunit-test-area');
+  Bram.trigger(el, { type: 'hello' }, messages.eventName);
+});

--- a/test/test.html
+++ b/test/test.html
@@ -12,5 +12,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.20/webcomponents.min.js"></script>
   <script src="../dist/bram.js"></script>
   <script src="element.js"></script>
+  <script src="listen.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This is more *web*, listen is a common verb used when listening to
events. Since all Bram.listen() does is create an observable for an
event, let's use that name.