### PR TITLE
Implements properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,27 @@ document.body.appendChild(render(model));
 
 Will show all three players as separate `<li>` elements.
 
+#### Properties
+
+You can set properties on an element using the special colon character like `:foo` on attributes. This allows you to pass non-string data to elements.
+
+```html
+<template>
+  <div :foo="{{foo}}">Foo!</div>
+</template>
+```
+
+```js
+var render = Bram.template(document.querySelector('template'));
+var model = Bram.model({
+  foo: 'bar'
+});
+
+document.body.appendChild(render(model));
+```
+
+Will render the `<div>` and set its `foo` property to the string `"bar"`.
+
 ### Bram.model
 
 Use **Bram.model** to create an observable model for use with your templates. If using a browser that doesn't supports [proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) you must pass in initial values for all of your properties so that they can be observed.

--- a/bram.js
+++ b/bram.js
@@ -356,7 +356,6 @@ function inspect(node, ref, paths) {
       break;
   }
 
-
   forEach.call(node.attributes || [], function(attrNode){
     // TODO see if this is important
     ref.id++;
@@ -364,12 +363,21 @@ function inspect(node, ref, paths) {
     if(ignoredAttrs[attrNode.name])
       return;
 
+    var name = attrNode.name;
+    var property = isPropAttr(name);
     var result = parse(attrNode.value);
     if(result.hasBinding) {
       result.throwIfMultiple();
       paths[ref.id] = function(node, model){
-        setupBinding(model, result, live.attr(node, attrNode.name));
+        if(property) {
+          node.removeAttribute(name);
+          setupBinding(model, result, live.prop(node, name.substr(1)));
+          return;
+        }
+        setupBinding(model, result, live.attr(node, name));
       };
+    } else if(property) {
+      console.log('still do this');
     }
   });
 
@@ -390,6 +398,10 @@ function specialTemplateAttr(template){
     if(template.getAttribute(attrName))
       return attrName;
   }
+}
+
+function isPropAttr(name) {
+  return name && name[0] === ':';
 }
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Web component architecture with Observables",
   "main": "bram.js",
   "scripts": {
-    "test": "testee test/simple.html test/model.html test/conditional.html test/lists.html test/texts.html test/parse.html test/children.html --browsers firefox"
+    "test": "testee test/simple.html test/model.html test/conditional.html test/lists.html test/texts.html test/parse.html test/children.html test/props.html --browsers firefox"
   },
   "keywords": [
     "web",

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -31,7 +31,6 @@ function inspect(node, ref, paths) {
       break;
   }
 
-
   forEach.call(node.attributes || [], function(attrNode){
     // TODO see if this is important
     ref.id++;
@@ -39,12 +38,21 @@ function inspect(node, ref, paths) {
     if(ignoredAttrs[attrNode.name])
       return;
 
+    var name = attrNode.name;
+    var property = isPropAttr(name);
     var result = parse(attrNode.value);
     if(result.hasBinding) {
       result.throwIfMultiple();
       paths[ref.id] = function(node, model){
-        setupBinding(model, result, live.attr(node, attrNode.name));
+        if(property) {
+          node.removeAttribute(name);
+          setupBinding(model, result, live.prop(node, name.substr(1)));
+          return;
+        }
+        setupBinding(model, result, live.attr(node, name));
       };
+    } else if(property) {
+      console.log('still do this');
     }
   });
 
@@ -65,4 +73,8 @@ function specialTemplateAttr(template){
     if(template.getAttribute(attrName))
       return attrName;
   }
+}
+
+function isPropAttr(name) {
+  return name && name[0] === ':';
 }

--- a/test/all.html
+++ b/test/all.html
@@ -34,6 +34,7 @@
   </div>
   <div class="tests">
     <iframe src="./children.html"></iframe>
+    <iframe src="./props.html"></iframe>
   </div>
 </body>
 </html>

--- a/test/props.html
+++ b/test/props.html
@@ -1,0 +1,59 @@
+<html>
+<head>
+  <title>A simple test</title>
+  <script src="../node_modules/webcomponents.js/webcomponents-lite.min.js"></script>
+  <script src="../bram.js"></script>
+  <link rel="import" href="../node_modules/mocha-test/mocha-test.html">
+  <style>
+    .green { background: green; }
+    .red { background: red; }
+    .blue { background: blue; }
+  </style>
+</head>
+<body>
+<template>
+  <div id="tester" :foo="{{foo}}"></div>
+</template>
+<div id="host"></div>
+
+  <script>
+  (function(){
+    var template = document.querySelector('template');
+    var model = window.model = Bram.model({
+      foo: 'bar'
+    });
+
+    var hydrate = Bram.template(template);
+    var tree = hydrate(model);
+    host.appendChild(tree);
+  })();
+  </script>
+  <mocha-test>
+  <template>
+    <script>
+      describe('Setting properties', function(){
+        it('are setting using :prop notation', function(){
+          assert.equal(tester.foo, 'bar', 'was set');
+        });
+
+        it('prop is not included in the resulting fragment', function(){
+          var val = tester.getAttribute(':foo');
+          assert.ok(!val);
+        });
+
+        describe('live-bound', function(){
+          after(function(){
+            model.foo = 'bar';
+          });
+
+          it('works', function(){
+            model.foo = 'qux';
+            assert.equal(tester.foo, 'qux');
+          });
+        });
+      });
+    </script>
+  </template>
+  </mocha-test>
+</body>
+</html>


### PR DESCRIPTION
This implements properties in templates using the syntax `:foo` to
distinguish this as a property to be set rather than an attribute.