### PR TITLE
Get string value when there are non-bindings.

### DIFF
--- a/bram.js
+++ b/bram.js
@@ -251,6 +251,7 @@ function ParseResult(){
   this.values = {};
   this.raw = '';
   this.hasBinding = false;
+  this.includesNonBindings = false;
 }
 
 ParseResult.prototype.getValue = function(scope){
@@ -271,7 +272,8 @@ ParseResult.prototype.getStringValue = function(scope){
 };
 
 ParseResult.prototype.compute = function(model){
-  return this.count() > 1
+  var useString = this.includesNonBindings || this.count() > 1;
+  return useString
     ? this.getStringValue.bind(this, model)
     : this.getValue.bind(this, model);
 };
@@ -336,6 +338,7 @@ function parse(str){
     i++;
   }
 
+  result.includesNonBindings = result.raw.length > 0;
   return result;
 }
 

--- a/src/expression.js
+++ b/src/expression.js
@@ -2,6 +2,7 @@ function ParseResult(){
   this.values = {};
   this.raw = '';
   this.hasBinding = false;
+  this.includesNonBindings = false;
 }
 
 ParseResult.prototype.getValue = function(scope){
@@ -22,7 +23,8 @@ ParseResult.prototype.getStringValue = function(scope){
 };
 
 ParseResult.prototype.compute = function(model){
-  return this.count() > 1
+  var useString = this.includesNonBindings || this.count() > 1;
+  return useString
     ? this.getStringValue.bind(this, model)
     : this.getValue.bind(this, model);
 };
@@ -87,5 +89,6 @@ function parse(str){
     i++;
   }
 
+  result.includesNonBindings = result.raw.length > 0;
   return result;
 }

--- a/test/parse.html
+++ b/test/parse.html
@@ -11,6 +11,18 @@
 <mocha-test>
 <template>
   <script>
+    describe('parse()', function(){
+      it('works with bindings at the end of the string', function(){
+        var result = Bram.parse('/some/{{foo}}');
+        assert.equal(result.hasBinding, true);
+        assert.equal(result.props()[0], 'foo');
+
+        var scope = new Bram.Scope({ foo: 'bar' });
+        var compute = result.compute(scope);
+        assert.equal(compute(), '/some/bar');
+      });
+    });
+
     describe('Parsing text with no magic tags', function(){
       it('hasBinding is false', function(){
         var result = Bram.parse('hello world');


### PR DESCRIPTION
Any time there are non-bindings as part of a string; that is any
characters that are not a binding, then we should always produce a
string value in ParseResult::compute