### PR TITLE
Fix the name used for an example element

### DIFF
--- a/docs/examples/pull-requests/prs.js
+++ b/docs/examples/pull-requests/prs.js
@@ -1,4 +1,4 @@
-class GitHubStars extends Bram.Element {
+class GitHubPRs extends Bram.Element {
   static get events() {
     return ['pullrequest'];
   }
@@ -25,7 +25,7 @@ class GitHubStars extends Bram.Element {
   }
 }
 
-customElements.define('github-stars', GitHubStars);
+customElements.define('github-prs', GitHubPRs);
 
 
 let render = Bram.template('#my-tmpl');
@@ -36,7 +36,7 @@ let model = Bram.model({
 let root = document.querySelector('#bram-info');
 root.appendChild(render(model));
 
-let gh = document.querySelector('github-stars');
+let gh = document.querySelector('github-prs');
 gh.onpullrequest = function(ev){
   let pr = ev.detail;
   model.prs.push(pr);

--- a/docs/index.html
+++ b/docs/index.html
@@ -185,8 +185,8 @@ customElements.define('todo-list', TodoList);
           <bram-panel title="HTML">
             <pre><code class="html">
 &lt;template id="my-tmpl"&gt;
-  &lt;github-stars repo="matthewp/bram"
-    limit="3"&gt;&lt;/github-stars&gt;
+  &lt;github-prs repo="matthewp/bram"
+    limit="3"&gt;&lt;/github-prs&gt;
 
   &lt;h1&gt;Latest PRs&lt;/h1&gt;
   &lt;ul&gt;
@@ -314,8 +314,8 @@ gh.onpullrequest = function(ev){
     <slot></slot>
   </template>
   <template id="my-tmpl">
-    <github-stars repo="matthewp/bram"
-      limit="3"></github-stars>
+    <github-prs repo="matthewp/bram"
+      limit="3"></github-prs>
 
     <h1>Latest PRs</h1>
     <ul>


### PR DESCRIPTION
It should be github-prs not github-stars, since it retrieves recent pull
requests.