### PR TITLE
typo near end of index page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -270,7 +270,7 @@ gh.onpullrequest = <span class="hljs-function"><span class="hljs-keyword">functi
       </div>
       <div class="advantage">
         <h2>Tiny</h2>
-        <p>Thanks to the web component APIs doing all of the heavy lifting, Bram gives you a lot, for very little. At 3kB you can use Bram to distribute widgets and not feel back about it.</p>
+        <p>Thanks to the web component APIs doing all of the heavy lifting, Bram gives you a lot, for very little. At 3kB you can use Bram to distribute widgets and not feel bad about it.</p>
       </div>
     </section>
 


### PR DESCRIPTION
"not feel back" should read "not feel bad" (right?)

BTW - cool little lib. This is def on my short-list of WC abstractions to explore. Smaller is better IMHO!