### PR TITLE
Keep track of next child during hydration

### DIFF
--- a/bram.umd.js
+++ b/bram.umd.js
@@ -234,6 +234,7 @@ Scope.prototype.add = function(object){
 
 function hydrate(link, callbacks, scope) {
   var paths = Object.keys(callbacks);
+  if(paths.length === 0) return;
   var id = +paths.shift();
   var cur = 0;
 
@@ -260,17 +261,21 @@ function hydrate(link, callbacks, scope) {
     });
     if(exit) return false;
 
-    some.call(node.childNodes, function(child){
+    var child = node.firstChild, nextChild;
+    while(child) {
+      nextChild = child.nextSibling;
       exit = check(child);
       if(exit) {
-        return true;
+        break;
       }
 
       exit = !traverse(child);
       if(exit) {
-        return true;
+        break;
       }
-    });
+      child = nextChild;
+    }
+
     return !exit;
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cloudydom": "^1.0.2",
     "highlight.js": "^9.8.0",
     "marked": "^0.3.6",
-    "mocha-test": "^2.0.3",
+    "mocha-test": "^2.0.4",
     "rollup": "^0.36.0",
     "script-type-module": "^1.0.0",
     "sw-precache": "^4.2.3",

--- a/src/hydrate.js
+++ b/src/hydrate.js
@@ -2,6 +2,7 @@ import { some, slice } from './util.js';
 
 function hydrate(link, callbacks, scope) {
   var paths = Object.keys(callbacks);
+  if(paths.length === 0) return;
   var id = +paths.shift();
   var cur = 0;
 
@@ -28,17 +29,21 @@ function hydrate(link, callbacks, scope) {
     });
     if(exit) return false;
 
-    some.call(node.childNodes, function(child){
+    var child = node.firstChild, nextChild;
+    while(child) {
+      nextChild = child.nextSibling;
       exit = check(child);
       if(exit) {
-        return true;
+        break;
       }
 
       exit = !traverse(child);
       if(exit) {
-        return true;
+        break;
       }
-    });
+      child = nextChild;
+    }
+
     return !exit;
   }
 }

--- a/test/conditional.html
+++ b/test/conditional.html
@@ -10,6 +10,15 @@
 </head>
 <body>
 <template id="conditional"><template if="{{condition}}">{{val}}</template></template>
+<template id="conditional2">
+  <template if="{{condition}}">
+    <span id="ittrue">True!</span>
+  </template>
+
+  <section>
+    <div class="two" :foo="{{bar}}">Stuff after</div>
+  </section>
+</template>
 <div id="host"></div>
 <mocha-test>
 <template>
@@ -55,6 +64,22 @@
           assert.equal(val.nodeValue, 'Wilbur');
         });
       });
+
+      describe('rendering next to other content', function(){
+        var hydrate = Bram.template(conditional2);
+        var model;
+
+        beforeEach(function(){
+          model = Bram.model({ bar: 'foo', condition: true });
+          host.appendChild(hydrate(model).tree);
+        });
+
+        it('doesn\'t affect adjacent content', function(){
+          var two = host.querySelector('.two');
+          console.log(two.foo, two);
+          assert.equal(two.foo, 'foo');
+        });
+      })
     });
   </script>
 </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,9 +1319,9 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha-test@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/mocha-test/-/mocha-test-2.0.3.tgz#a17f0525e66861762d3c2bcb197b74c479f75ad8"
+mocha-test@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/mocha-test/-/mocha-test-2.0.4.tgz#7aa366d2f2db91342db104261e65a5d9722a4ba5"
   dependencies:
     chai "^3.5.0"
     mocha "^2.5.3"


### PR DESCRIPTION
When hydrating each callback can affect the live childNodes NodeList, so
using that to recurse is not the way to go. Instead use a while loop
with firstChild/nextSibling, always caching the nextSibling value before
each callback is called, so we call everything on the right node.